### PR TITLE
Add MASS to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,8 @@ Suggests:
     parallel,
     doParallel,
     itertools,
-    microbenchmark
+    microbenchmark,
+    MASS
 Description: Dirichlet process mixture of multivariate normal, skew normal or skew t-distributions
              modeling oriented towards flow-cytometry data preprocessing applications. Method is 
              detailed in: Hejblum, Alkhassimn, Gottardo, Caron & Thiebaut (2019) <doi: 10.1214/18-AOAS1209>.


### PR DESCRIPTION
While we were submitting ggplot2 to CRAN, it became apparent that MASS is required for running the examples in NPflow.
ggplot2 has demoted the MASS package from an import to suggested package, so using `stat_density_2d()` requires listing MASS in your dependencies.